### PR TITLE
Update go-search-replace dependency to 0.0.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.2
 toolchain go1.23.5
 
 require (
-	github.com/Automattic/go-search-replace v0.0.0-20250123122348-b7b61468a435
+	github.com/Automattic/go-search-replace v0.0.0-20250619025147-865525ecd0df
 	github.com/klauspost/pgzip v1.2.6
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Automattic/go-search-replace v0.0.0-20250123122348-b7b61468a435 h1:9ASUY+l672Fmw5jrYfRWE1Le4sm+KzmCK6ItIpipNsM=
 github.com/Automattic/go-search-replace v0.0.0-20250123122348-b7b61468a435/go.mod h1:R1pI9mw8IOlBhnCtqv6ACeevzNwhBMxZyPFXTWJfdqg=
+github.com/Automattic/go-search-replace v0.0.0-20250619025147-865525ecd0df h1:fTWM88EquHd24aZqY2Fa9/Z/ZyZC79H3pGJ+Vv0S714=
+github.com/Automattic/go-search-replace v0.0.0-20250619025147-865525ecd0df/go.mod h1:R1pI9mw8IOlBhnCtqv6ACeevzNwhBMxZyPFXTWJfdqg=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Automattic/go-search-replace v0.0.0-20250123122348-b7b61468a435 h1:9ASUY+l672Fmw5jrYfRWE1Le4sm+KzmCK6ItIpipNsM=
-github.com/Automattic/go-search-replace v0.0.0-20250123122348-b7b61468a435/go.mod h1:R1pI9mw8IOlBhnCtqv6ACeevzNwhBMxZyPFXTWJfdqg=
 github.com/Automattic/go-search-replace v0.0.0-20250619025147-865525ecd0df h1:fTWM88EquHd24aZqY2Fa9/Z/ZyZC79H3pGJ+Vv0S714=
 github.com/Automattic/go-search-replace v0.0.0-20250619025147-865525ecd0df/go.mod h1:R1pI9mw8IOlBhnCtqv6ACeevzNwhBMxZyPFXTWJfdqg=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=


### PR DESCRIPTION
As per the title.

~~I'm not entirely clear why `go.sum` isn't cleaning out the old dependency.~~ `go mod tidy` fixes that up.

Note - the version corresponds to this (the hash in the version is the commit number) https://github.com/Automattic/go-search-replace/releases/tag/0.0.11