### PR TITLE
chore: add dev container configuration

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {
+      "version": "1.0.15",
+      "resolved": "ghcr.io/devcontainers-extra/features/ripgrep@sha256:0dfc0ac16f0d6aa754d006a138fd4cb4a62c245d308306edf8ad1b7a80b8fdf2",
+      "integrity": "sha256:0dfc0ac16f0d6aa754d006a138fd4cb4a62c245d308306edf8ad1b7a80b8fdf2"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.0.12",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:183d18b42de353e3689615fd21eb67427bc1f763c5b830c2798dcbb993da2049",
+      "integrity": "sha256:183d18b42de353e3689615fd21eb67427bc1f763c5b830c2798dcbb993da2049"
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f",
+      "integrity": "sha256:fedd4c11f7adfb64283b578dddc7da906728daa25fa293351c9d913231acf12f"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+	"name": "Go",
+	"image": "mcr.microsoft.com/devcontainers/go:1.25-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/node:2": {
+			"version": "lts",
+			"npmVersion": "latest",
+			"pnpmVersion": "none",
+			"nvmVersion": "latest"
+		},
+		"ghcr.io/devcontainers-extra/features/ripgrep:1": {
+			"version": "latest"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"dlech.chmod",
+				"zhiayang.tabindentspacealign",
+				"GitHub.copilot",
+				"GitHub.copilot-chat",
+				"github.vscode-github-actions",
+				"ms-vsliveshare.vsliveshare",
+				"phoihos.git-commit-message-editor",
+				"mhutchie.git-graph",
+				"huizhou.githd",
+				"Everspace.rightclick-git"
+			],
+			"settings": {
+				"chat.tools.terminal.terminalProfile.linux": {
+					"path": "/bin/sh",
+					"args": ["-c", "/usr/bin/bash --init-file \"$(code --locate-shell-integration-path bash)\""]
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This pull request adds configuration files for a development container setup, enhancing the development environment with essential tools and editor extensions. The most important changes are grouped below:

Dev container setup:

* Added `.devcontainer/devcontainer.json` to define a development container based on the Go 1.25 image, including features for GitHub CLI, Node.js, and ripgrep, as well as recommended VS Code extensions and settings.
* Added `.devcontainer/devcontainer-lock.json` to lock the versions of the dev container features for reproducibility, specifying exact versions and hashes for GitHub CLI, Node.js, and ripgrep.